### PR TITLE
Twks to JOEBVP

### DIFF
--- a/joebvp/VPmeasure.py
+++ b/joebvp/VPmeasure.py
@@ -544,7 +544,7 @@ def go(specfilename, parfilename):
     app.exec_()
 
 def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
-    '''
+    """
     Takes a number of input files and fits the lines in them.  The fitting algorithm will
     be run until convergence for each input file. The program will then ask whether to run the failed
     runs in GUI mode.
@@ -553,16 +553,19 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
     ----------
     spec : string or XSpectrum1D
         The spectrum to be fitted with the input lines
-
     filelist : list of strings or str
         This should be a list containing the names of VP input files or a string referring to a file simply
         listing the input files.
         See joebvpfit.readpars for details of file format
+    outparfile : str, optional
+        Not sure what this does [complete here].
+    outmodelfile: str, optional
+        Not sure what this does [complete here].
 
     **kwargs : maxiter, itertol
         These are fed on to the joebvp.fit_to_convergence() function
 
-    '''
+    """
     if isinstance(spec,str):
         spectofit = readspec(spec)
         specfile = spectofit.filename
@@ -589,10 +592,10 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
     fails = [] # store failures filenames
     for i,ff in enumerate(listofiles):
         i += 1
-        fitpars,fiterrors,parinfo,linecmts=joebvpfit.readpars(ff)
+        fitpars, fiterrors, parinfo, linecmts = joebvpfit.readpars(ff)
         cfg.wavegroups = []
         try:
-            fitpars,fiterrors=joebvpfit.fit_to_convergence(wave,normflux,normsig,fitpars,parinfo)
+            fitpars,fiterrors=joebvpfit.fit_to_convergence(wave,normflux,normsig,fitpars,parinfo, **kwargs)
             print('VPmeasure: Fit converged:', ff)
             paroutfilename = ff[:-6] + 'VP'
             modeloutfilename = ff[:-7] + '_VPmodel.fits'
@@ -617,24 +620,20 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
             for ff in fails:
                 go(spec, ff)
 
-    # ask whether to concatenate and create fits inspection files
-    while True:
-        answer = raw_input("VPmeasure: Would you like to concatenate all .VP outputs in the working directory and create a FitsInspection.pdf file? (y/n): ")
-        if answer in ['y','n', 'yes','no']:
-            break
-    if answer in ['y', 'yes']:
-        concatenate_all()
-    else:
-        print("VPmeasure: Done.")
+    # Concatenate and create fits inspection files
+    concatenate_all()
+    print("VPmeasure: Done.")
 
 def concatenate_all():
+    """Takes all *.VP files in the working directory, and concatenates them into a single VP file
+    as well as creates a single PDF file for fit inspection."""
     # concatenate and inspect fit
     print("VPmeasure: concatenating individual outputs and creating figures for inspection.")
     os.system("ls *.VP > all_VP.txt")
     jbu.concatenate_line_tables("all_VP.txt")
     reload(cfg)  # Clear out the LSFs from the last fit
     jbu.inspect_fits("compiledVPoutputs.dat")
-    print("VPmeasure: Done.")
+
 
 if __name__ == '__main__':
         import sys

--- a/joebvp/VPmeasure.py
+++ b/joebvp/VPmeasure.py
@@ -582,6 +582,7 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
     normflux=spectofit.flux.value/spectofit.co.value
     normsig=spectofit.sig.value/spectofit.co.value
     cfg.wave=wave
+    cfg.spectrum = spectofit # need this for defining bad pixels later
 
     q_pass = 0
     q_fail = 0
@@ -606,7 +607,7 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
     print("VPmeasure: {}/{} fits converged, {}/{} failed (see log for details).\n".format(q_pass, i, q_fail, i))
 
     # ask whether run GUI mode on failures
-    if q_fail >= 0:
+    if q_fail > 0:
         print("VPmeasure: Failed runs are: {}\n".format(fails))
         while True:
             answer = raw_input("VPmeasure: Would you like to run the failed fits in GUI mode? (y/n): ")

--- a/joebvp/VPmeasure.py
+++ b/joebvp/VPmeasure.py
@@ -621,17 +621,22 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
                 go(spec, ff)
 
     # Concatenate and create fits inspection files
-    concatenate_all()
+    concatenate_all(spectofit)
     print("VPmeasure: Done.")
 
-def concatenate_all():
+def concatenate_all(spectrum):
     """Takes all *.VP files in the working directory, and concatenates them into a single VP file
-    as well as creates a single PDF file for fit inspection."""
+    as well as creates a single PDF file for fit inspection.
+
+    spectrum : XSpectrum1D
+        Original spectrum
+    """
     # concatenate and inspect fit
     print("VPmeasure: concatenating individual outputs and creating figures for inspection.")
     os.system("ls *.VP > all_VP.txt")
     jbu.concatenate_line_tables("all_VP.txt")
     reload(cfg)  # Clear out the LSFs from the last fit
+    cfg.spectrum = spectrum
     jbu.inspect_fits("compiledVPoutputs.dat")
 
 

--- a/joebvp/VPmeasure.py
+++ b/joebvp/VPmeasure.py
@@ -558,9 +558,9 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
         listing the input files.
         See joebvpfit.readpars for details of file format
     outparfile : str, optional
-        Not sure what this does [complete here].
+        Output file for fitted line parameters.
     outmodelfile: str, optional
-        Not sure what this does [complete here].
+        Output fits file for fitted model as the 'flux'.
 
     **kwargs : maxiter, itertol
         These are fed on to the joebvp.fit_to_convergence() function
@@ -594,7 +594,7 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
         i += 1
         fitpars, fiterrors, parinfo, linecmts = joebvpfit.readpars(ff)
         cfg.wavegroups = []
-        try:
+        if 1:
             fitpars,fiterrors=joebvpfit.fit_to_convergence(wave,normflux,normsig,fitpars,parinfo, **kwargs)
             print('VPmeasure: Fit converged:', ff)
             paroutfilename = ff[:-6] + 'VP'
@@ -602,7 +602,7 @@ def batch_fit(spec, filelist, outparfile=None, outmodelfile=None, **kwargs):
             joebvpfit.writelinepars(fitpars, fiterrors, parinfo, specfile, paroutfilename, linecmts)
             joebvpfit.writeVPmodel(modeloutfilename, wave, fitpars, normflux, normsig)
             q_pass += 1
-        except:
+        else: #except:
             print('VPmeasure: Fitting failed:',ff)
             fails += [ff]
             q_fail += 1

--- a/joebvp/VPmeasure.py
+++ b/joebvp/VPmeasure.py
@@ -20,6 +20,7 @@ from joebvp import utils as jbu
 import os
 from linetools.spectra.io import readspec
 import numpy as np
+from astropy.constants import c
 
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_qt5agg import (
@@ -30,7 +31,7 @@ modpath=os.path.abspath(os.path.dirname(__file__))
 print os.path.abspath(os.path.dirname(__file__))
 Ui_MainWindow, QMainWindow = loadUiType(modpath+'/mainvpwindow.ui')
 
-c= cfg.c / 1e5
+c= c.to('km/s').value
 
 class LineParTableModel(QAbstractTableModel):
     def __init__(self,fitpars,fiterrors,parinfo,linecmts=None,parent=None):
@@ -271,14 +272,6 @@ class Main(QMainWindow, Ui_MainWindow):
         cfg.wave=self.wave
         cfg.normflux=self.normflux
         cfg.filename=self.specfilename
-
-        # define bad pixels
-        cond_badpix = (self.spectrum.wavelength <= self.spectrum.wvmin) | \
-                      (self.spectrum.wavelength >= self.spectrum.wvmax) | \
-                      (self.spectrum.sig <= 0) | \
-                      (self.spectrum.flux / self.spectrum.sig < cfg.min_sn)  # bad S/N
-        cfg.bad_pixels = np.where(cond_badpix)[0]  # this variable stores the indices of bad pixels
-
 
         if not parfilename==None:
             self.initialpars(parfilename)
@@ -541,7 +534,6 @@ def go(specfilename, parfilename):
     from astropy.io import fits as pf
     from astropy.io import ascii
     from linetools.spectra.io import readspec
-
 
     app = QtWidgets.QApplication.instance()
     if not app:

--- a/joebvp/cfg.py
+++ b/joebvp/cfg.py
@@ -19,7 +19,7 @@ field=''
 homedir=os.path.expanduser('~')
 spectrum = []
 bad_pixels = []  # this will store bad pixel indices
-min_sn = 0.2  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
+min_sn = 0.0  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
 # spectral_gaps = [[0,1174], [1300,1307], [1312.5,1330], [1560,1575], [1750,2000]]  # these gaps can be used to define bad pixels
 
 
@@ -39,14 +39,15 @@ else:  # this is for the casual user
     instr=['COS','COS']
     gratings=['G130M','G160M']
     slits=['NA','NA']
-    lsfranges=np.array([[1160,1450],[1450,1800]])
+    lsfranges=np.array([[1160,1388],[1388,1800]])
     lps=['3','3']
-    cen_wave=['1318','1600']
+    cen_wave=['1318','1577']
     # spectral gaps for defyning bad pixels
     # spectral_gaps = [[0,1385], [1387,1387.6], [1558.4,1575.4], [1577.77,1578.3], [1748,2000]]  # BAL
-    spectral_gaps = [[0,1174], [1300,1307], [1312.5,1330], [1560,1575], [1750,2000]]  # J0321
-
-
+    # spectral_gaps = [[0,1174], [1300,1307], [1312.5,1330], [1560,1575], [1750,2000]]  # J0321
+    # spectral_gaps = [[0,1388], [1558.56,1578.54], [1747,3000]]  # J0315
+    spectral_gaps = [[0,1383.71], [1386.7,1387.8], [1558.56,1578.54], [1747,3000]]  # J0326
+    # spectral_gaps = [[0,1173], [1301, 1307], [1315.98,1316.67], [1317.44,1328.07], [1585.13,1602.03], [1774,3000]]  # Q0349-146
 
 # fundamental constants
 echarge = 4.803204505713468e-10

--- a/joebvp/cfg.py
+++ b/joebvp/cfg.py
@@ -19,8 +19,10 @@ field=''
 homedir=os.path.expanduser('~')
 spectrum = []
 bad_pixels = []  # this will store bad pixel indices
-min_sn = 0.5  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
-spectral_gaps = [[0,1174], [1300,1307], [1312.5,1330], [1560,1575], [1750,2000]]  # these gaps can be used to define bad pixels
+min_sn = 0.2  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
+# spectral_gaps = [[0,1174], [1300,1307], [1312.5,1330], [1560,1575], [1750,2000]]  # these gaps can be used to define bad pixels
+
+
 
 Todd = False
 if Todd:
@@ -40,6 +42,11 @@ else:  # this is for the casual user
     lsfranges=np.array([[1160,1450],[1450,1800]])
     lps=['3','3']
     cen_wave=['1318','1600']
+    # spectral gaps for defyning bad pixels
+    # spectral_gaps = [[0,1385], [1387,1387.6], [1558.4,1575.4], [1577.77,1578.3], [1748,2000]]  # BAL
+    spectral_gaps = [[0,1174], [1300,1307], [1312.5,1330], [1560,1575], [1750,2000]]  # J0321
+
+
 
 # fundamental constants
 echarge = 4.803204505713468e-10

--- a/joebvp/cfg.py
+++ b/joebvp/cfg.py
@@ -57,7 +57,9 @@ c2 = 29979245800.0
 # store LSFs and FGs
 lsfs=[]
 fgs=[]
-
+wavegroups=[]
+wgidxs=[]
+uqwgidxs=[]
 
 outputdir = './'
 

--- a/joebvp/cfg.py
+++ b/joebvp/cfg.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+from astropy.constants import c as C
 
 wave=0
 flux=0
@@ -18,7 +19,8 @@ field=''
 homedir=os.path.expanduser('~')
 spectrum = []
 bad_pixels = []  # this will store bad pixel indices
-min_sn = 0.2  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
+min_sn = 0.5  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
+spectral_gaps = [[0,1174], [1300,1307], [1312.5,1330], [1560,1575], [1750,2000]]  # these gaps can be used to define bad pixels
 
 Todd = False
 if Todd:
@@ -38,6 +40,16 @@ else:  # this is for the casual user
     lsfranges=np.array([[1160,1450],[1450,1800]])
     lps=['3','3']
     cen_wave=['1318','1600']
+
+# fundamental constants
+echarge = 4.803204505713468e-10
+m_e = 9.10938291e-28
+c = C.to('cm/s').value
+c2 = 29979245800.0
+
+# store LSFs and FGs
+lsfs=[]
+fgs=[]
 
 
 outputdir = './'
@@ -62,3 +74,7 @@ x_labelpad = 0
 y_labelpad = -3
 label_ypos = 0.2 * (ylim[0]+ylim[1])
 label_fontsize = 8
+
+
+# Handy definitions
+lyseries=np.array([913.8260,914.0390,914.2860,914.5760,914.919,915.329,915.824,916.429,917.1806,918.1294,919.3514,920.9631,923.1504,926.2257,930.7483,937.8035,949.7431,972.5368,1025.7223,1215.6701])

--- a/joebvp/cfg.py
+++ b/joebvp/cfg.py
@@ -18,7 +18,7 @@ field=''
 homedir=os.path.expanduser('~')
 spectrum = []
 bad_pixels = []  # this will store bad pixel indices
-min_sn = 0.0  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
+min_sn = 0.2  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
 
 Todd = False
 if Todd:
@@ -35,83 +35,23 @@ else:  # this is for the casual user
     instr=['COS','COS']
     gratings=['G130M','G160M']
     slits=['NA','NA']
-    lsfranges=np.array([[1100,1450],[1450,1800]])
+    lsfranges=np.array([[1160,1450],[1450,1800]])
     lps=['3','3']
-    cen_wave=['1327','1600']
+    cen_wave=['1318','1600']
 
 
-echarge=4.803204505713468e-10
-m_e=9.10938291e-28
-c=29979245800.0
+outputdir = './'
 
-lyseries=np.array([913.8260,914.0390,914.2860,914.5760,914.919,915.329,915.824,916.429,917.1806,918.1294,919.3514,920.9631,923.1504,926.2257,930.7483,937.8035,949.7431,972.5368,1025.7223,1215.6701])
-NIseries=[1199.5496, 1200.2233, 1200.7098]
-NIIseries=[533.5099, 644.6337, 671.4102, 915.6131, 1083.9937]
-NIIIseries=[374.204,684.996,685.513,763.34,989.799]
-NIVseries=[247.205, 765.148, 1486.496]
-NVseries=[1238.821, 1242.804]
-OIseries=[791.5136, 791.9732,877.7983, 877.8787,971.7371, 971.7376, 971.7382,988.5778,988.6549, 988.7734,1302.1685]
-OIIseries=[376.693, 376.745, 387.651, 387.901, 388.058, 391.912, 391.943, 392.002, 418.598, 418.881, 419.065, 429.918, 430.041, 430.177, 539.0855, 539.5489, 539.8544, 832.7572, 833.3294, 834.4655]
-OIIIseries=[228.825, 248.538, 255.155, 262.662, 263.692, 264.257, 266.967, 275.281, 280.234, 303.411, 305.596, 374.005, 475.153, 507.391, 702.332, 832.927]
-OIVseries=[238.36, 279.631, 553.33, 554.075, 608.398, 787.711, 1397.232, 1399.78]
-OVseries=[629.73, 1218.344]
-OVIseries=[1031.9261, 1037.6167]
-SiIIseries=[889.7228, 899.4063, 989.8731, 1020.6989, 1190.4158, 1193.2897, 1260.4221, 1304.3702, 1526.7066, 1808.0126]
-SiIIIseries=[408.378, 423.817, 426.644, 437.255, 466.129, 566.613, 1206.5, 1892.03]
-SiIVseries=[300.517, 300.531, 310.234, 310.257, 327.137, 327.181, 361.56, 361.659, 457.818, 458.155, 1393.755, 1402.77]
-SIIseries=[558.755, 558.924, 559.131, 571.156, 571.364, 571.779, 574.397, 576.057, 576.978, 593.507, 593.835, 594.475, 600.661, 602.446, 603.43, 640.412, 640.902, 641.767, 662.267, 664.315, 665.519, 763.657, 764.42, 765.693, 906.885, 910.484, 912.735, 1250.578, 1253.805, 1259.518]
-SIIIseries=[476.351, 480.533, 484.172, 677.746, 681.47, 698.731, 724.289, 1012.501, 1190.191]
-SIVseries=[368.99, 391.558, 551.17, 657.34, 744.907, 748.4, 809.668, 1062.662, 1398.05, 1404.8]
-SVseries=[286.094, 786.48, 1199.134]
-SVIseries=[248.99, 249.27, 933.378, 944.523]
-CIseries=[945.191, 1277.2454, 1280.1353, 1328.8333, 1560.3092, 1613.3763, 1656.9283]
-CIIseries=[438.773, 438.824, 466.352, 466.407, 530.274, 538.406, 543.257, 549.3195, 549.3785, 551.68, 560.2394, 576.8748, 594.8, 635.9945, 687.0526, 858.0918, 903.6235, 903.9616, 1036.3367, 1334.5323, 2324.214, 2325.403]
-CIIIseries=[270.324, 274.051, 280.043, 288.423, 291.3261, 310.1697, 322.5741, 386.2028, 977.02, 1908.734]
-CIVseries=[244.907, 244.911, 312.422, 312.453, 1548.195, 1550.77]
-FeIIseries=[2260.7805, 2344.214, 2367.5905, 2374.4612, 2382.765, 2586.65, 2600.1729]
-FeIIIseries=[734.296, 735.247, 735.344, 808.078, 813.379, 814.137, 823.256, 824.799, 826.387, 844.288, 850.907, 854.2, 858.551, 858.609, 859.723, 1122.524, 1207.05, 1214.562]
-FeIVseries=[525.689, 526.293, 526.634]
-FeVseries=[363.444, 365.44, 386.261, 387.984]
-FeXIVseries=[252.19, 257.385, 274.203, 334.178]
-FeXVIseries=[335.407, 360.798]
-NeIIseries=[445.0397, 446.2556, 460.7284]
-NeIIIseries=[313.059, 345.448, 488.108, 489.505]
-NeIVseries=[334.056, 541.127, 542.073, 543.891]
-NeVseries=[329.151, 357.95, 480.41, 568.42]
-NeVIseries=[399.82, 401.14, 433.176, 558.59, 993.0, 997.4]
-NeVIIseries=[465.221, 895.18]
-NeVIIIseries=[770.409, 780.324]
-MgIXseries=[368.071, 705.72]
-MgXseries=[609.79, 624.95]
-ArIVseries=[451.2, 451.87, 452.91, 840.03, 843.77, 850.6]
-HeIseries=[506.2, 506.5702, 507.0576, 507.7178, 508.6431, 509.9979, 512.0982, 515.6165, 522.2128, 537.0296, 584.334]
-HeIIseries=[229.431, 229.736, 230.139, 230.686, 231.454, 232.584, 234.347, 237.331, 243.027, 256.317, 303.7822]
-
-multiplets=[lyseries,NIseries,NIIseries,NIIIseries,NIVseries,NVseries,OIseries,OIIseries,OIIIseries,OIVseries,OVseries,OVIseries,FeIIseries,FeIIIseries,FeIVseries,FeVseries,FeXIVseries,FeXVIseries,NeIIseries,NeIIIseries,NeIVseries,NeVseries,NeVIseries,NeVIIseries,NeVIIIseries,MgIXseries,MgXseries,ArIVseries,HeIseries,HeIIseries,CIseries,CIIseries,CIIseries,CIVseries,]
-
-wavegroups=[]
-wgidxs=[]
-uqwgidxs=[]
-lsfs=[]
-fgs=[]
-
-#Atomic data
-lams=np.array([])
-fosc=np.array([])
-gam=np.array([])
-
-outputdir='./'
-
-VPparoutfile=outputdir+field+'_VP.dat'
-VPmodeloutfile=outputdir+field+'VPmodel.fits'
-contoutfile=outputdir+'continua.dat'
-largeVPparfile=outputdir+'_VP_log.dat'
-defaultcol=13.1
-defaultb=20.0
-defaultvlim=1000.
-lowblim=4.
-upperblim=85.
-upperblim_HI=210.
+VPparoutfile = outputdir + field + '_VP.dat'
+VPmodeloutfile = outputdir + field + 'VPmodel.fits'
+contoutfile = outputdir + 'continua.dat'
+largeVPparfile = outputdir + '_VP_log.dat'
+defaultcol = 13.1
+defaultb = 20.0
+defaultvlim = 1000.
+lowblim = 4.
+upperblim = 85.
+upperblim_HI = 210.
 
 # Plotting
 ylim = (-0.2, 1.4)

--- a/joebvp/cfg_old.py
+++ b/joebvp/cfg_old.py
@@ -1,0 +1,124 @@
+import os
+import numpy as np
+
+wave=0
+flux=0
+sigup=0
+normwave=0
+normflux=0
+normsig=0
+fitidx=0
+fitcoeff=0
+fitcovmtx=0
+fiterrors=0
+origpars=0
+origparinfo=0
+filename=''
+field=''
+homedir=os.path.expanduser('~')
+spectrum = []
+bad_pixels = []  # this will store bad pixel indices
+min_sn = 0.2  # float, minimum signal to noise to include pixels in fit; leave as 0 and nothing will happen
+
+Todd = False
+if Todd:
+    lsf='COS_LP1'
+    instr=['COS','COS','COS','COS','STIS']
+    gratings=['G130M','G160M','G185M','G225M','E230M']
+    slits=['NA','NA','NA','NA','0.2x0.2']
+    lsfranges=np.array([[1100,1400],[1400,1800],[1800,2100],[2100,2278],[2278,4100]])
+    lps=['1','1','1','1','1']
+    cen_wave=['1327','1600','1953','2250','2707']
+
+else:  # this is for the casual user
+    lsf='COS_LP3'
+    instr=['COS','COS']
+    gratings=['G130M','G160M']
+    slits=['NA','NA']
+    lsfranges=np.array([[1160,1450],[1450,1800]])
+    lps=['3','3']
+    cen_wave=['1318','1600']
+
+
+echarge=4.803204505713468e-10
+m_e=9.10938291e-28
+c=29979245800.0
+
+lyseries=np.array([913.8260,914.0390,914.2860,914.5760,914.919,915.329,915.824,916.429,917.1806,918.1294,919.3514,920.9631,923.1504,926.2257,930.7483,937.8035,949.7431,972.5368,1025.7223,1215.6701])
+NIseries=[1199.5496, 1200.2233, 1200.7098]
+NIIseries=[533.5099, 644.6337, 671.4102, 915.6131, 1083.9937]
+NIIIseries=[374.204,684.996,685.513,763.34,989.799]
+NIVseries=[247.205, 765.148, 1486.496]
+NVseries=[1238.821, 1242.804]
+OIseries=[791.5136, 791.9732,877.7983, 877.8787,971.7371, 971.7376, 971.7382,988.5778,988.6549, 988.7734,1302.1685]
+OIIseries=[376.693, 376.745, 387.651, 387.901, 388.058, 391.912, 391.943, 392.002, 418.598, 418.881, 419.065, 429.918, 430.041, 430.177, 539.0855, 539.5489, 539.8544, 832.7572, 833.3294, 834.4655]
+OIIIseries=[228.825, 248.538, 255.155, 262.662, 263.692, 264.257, 266.967, 275.281, 280.234, 303.411, 305.596, 374.005, 475.153, 507.391, 702.332, 832.927]
+OIVseries=[238.36, 279.631, 553.33, 554.075, 608.398, 787.711, 1397.232, 1399.78]
+OVseries=[629.73, 1218.344]
+OVIseries=[1031.9261, 1037.6167]
+SiIIseries=[889.7228, 899.4063, 989.8731, 1020.6989, 1190.4158, 1193.2897, 1260.4221, 1304.3702, 1526.7066, 1808.0126]
+SiIIIseries=[408.378, 423.817, 426.644, 437.255, 466.129, 566.613, 1206.5, 1892.03]
+SiIVseries=[300.517, 300.531, 310.234, 310.257, 327.137, 327.181, 361.56, 361.659, 457.818, 458.155, 1393.755, 1402.77]
+SIIseries=[558.755, 558.924, 559.131, 571.156, 571.364, 571.779, 574.397, 576.057, 576.978, 593.507, 593.835, 594.475, 600.661, 602.446, 603.43, 640.412, 640.902, 641.767, 662.267, 664.315, 665.519, 763.657, 764.42, 765.693, 906.885, 910.484, 912.735, 1250.578, 1253.805, 1259.518]
+SIIIseries=[476.351, 480.533, 484.172, 677.746, 681.47, 698.731, 724.289, 1012.501, 1190.191]
+SIVseries=[368.99, 391.558, 551.17, 657.34, 744.907, 748.4, 809.668, 1062.662, 1398.05, 1404.8]
+SVseries=[286.094, 786.48, 1199.134]
+SVIseries=[248.99, 249.27, 933.378, 944.523]
+CIseries=[945.191, 1277.2454, 1280.1353, 1328.8333, 1560.3092, 1613.3763, 1656.9283]
+CIIseries=[438.773, 438.824, 466.352, 466.407, 530.274, 538.406, 543.257, 549.3195, 549.3785, 551.68, 560.2394, 576.8748, 594.8, 635.9945, 687.0526, 858.0918, 903.6235, 903.9616, 1036.3367, 1334.5323, 2324.214, 2325.403]
+CIIIseries=[270.324, 274.051, 280.043, 288.423, 291.3261, 310.1697, 322.5741, 386.2028, 977.02, 1908.734]
+CIVseries=[244.907, 244.911, 312.422, 312.453, 1548.195, 1550.77]
+FeIIseries=[2260.7805, 2344.214, 2367.5905, 2374.4612, 2382.765, 2586.65, 2600.1729]
+FeIIIseries=[734.296, 735.247, 735.344, 808.078, 813.379, 814.137, 823.256, 824.799, 826.387, 844.288, 850.907, 854.2, 858.551, 858.609, 859.723, 1122.524, 1207.05, 1214.562]
+FeIVseries=[525.689, 526.293, 526.634]
+FeVseries=[363.444, 365.44, 386.261, 387.984]
+FeXIVseries=[252.19, 257.385, 274.203, 334.178]
+FeXVIseries=[335.407, 360.798]
+NeIIseries=[445.0397, 446.2556, 460.7284]
+NeIIIseries=[313.059, 345.448, 488.108, 489.505]
+NeIVseries=[334.056, 541.127, 542.073, 543.891]
+NeVseries=[329.151, 357.95, 480.41, 568.42]
+NeVIseries=[399.82, 401.14, 433.176, 558.59, 993.0, 997.4]
+NeVIIseries=[465.221, 895.18]
+NeVIIIseries=[770.409, 780.324]
+MgIXseries=[368.071, 705.72]
+MgXseries=[609.79, 624.95]
+ArIVseries=[451.2, 451.87, 452.91, 840.03, 843.77, 850.6]
+HeIseries=[506.2, 506.5702, 507.0576, 507.7178, 508.6431, 509.9979, 512.0982, 515.6165, 522.2128, 537.0296, 584.334]
+HeIIseries=[229.431, 229.736, 230.139, 230.686, 231.454, 232.584, 234.347, 237.331, 243.027, 256.317, 303.7822]
+
+multiplets=[lyseries,NIseries,NIIseries,NIIIseries,NIVseries,NVseries,OIseries,OIIseries,OIIIseries,OIVseries,OVseries,OVIseries,FeIIseries,FeIIIseries,FeIVseries,FeVseries,FeXIVseries,FeXVIseries,NeIIseries,NeIIIseries,NeIVseries,NeVseries,NeVIseries,NeVIIseries,NeVIIIseries,MgIXseries,MgXseries,ArIVseries,HeIseries,HeIIseries,CIseries,CIIseries,CIIseries,CIVseries,]
+
+wavegroups=[]
+wgidxs=[]
+uqwgidxs=[]
+lsfs=[]
+fgs=[]
+
+#Atomic data
+lams=np.array([])
+fosc=np.array([])
+gam=np.array([])
+
+outputdir='./'
+
+VPparoutfile=outputdir+field+'_VP.dat'
+VPmodeloutfile=outputdir+field+'VPmodel.fits'
+contoutfile=outputdir+'continua.dat'
+largeVPparfile=outputdir+'_VP_log.dat'
+defaultcol=13.1
+defaultb=20.0
+defaultvlim=1000.
+lowblim=4.
+upperblim=85.
+upperblim_HI=210.
+
+# Plotting
+ylim = (-0.2, 1.4)
+xtick_fontsize = 'small'
+ytick_fontsize = 'small'
+xy_fontsize = 'small'
+x_labelpad = 0
+y_labelpad = -3
+label_ypos = 0.2 * (ylim[0]+ylim[1])
+label_fontsize = 8

--- a/joebvp/joebvpfit.py
+++ b/joebvp/joebvpfit.py
@@ -39,8 +39,8 @@ def unfoldpars(pars,numpars=5):
 
 def voigtfunc(vwave,vpars):
 	### Check to see if cfg variables are set
-	if isinstance(cfg.fitidx,int)|isinstance(cfg.wave,int):
-		cfg.fitidx = fitpix(vwave,vpars)
+	if isinstance(cfg.fitidx, int)|isinstance(cfg.wave, int):
+		cfg.fitidx = fitpix(vwave, vpars)
 		cfg.wave = vwave
 	if len(cfg.lsfs) == 0:
 		makevoigt.get_lsfs()
@@ -54,7 +54,7 @@ def voigterrfunc(p,x,y,err,fjac=None):
 	fp=foldpars(p)
 	model=voigtfunc(x,fp)
 	status=0
-	return([status,(y[cfg.fitidx]-model[cfg.fitidx])/err[cfg.fitidx]])
+	return([status, (y[cfg.fitidx] - model[cfg.fitidx]) / err[cfg.fitidx]])
 
 def fitpix(wave,pararr):
 	ll=pararr[0]
@@ -102,12 +102,12 @@ def prepparinfo(linepars,parflags):
 		parinfo[numpars*i+1]['limits']=[round(col-5.,2),round(col+5.,2)]
 		parinfo[numpars*i+2]['limited']=[1,1]
 		### adjust b-value limits to allow for broadened HI features
-		lydiff=abs(linepars[0][i]-cfg.lyseries)
+		lydiff=abs(linepars[0][i] - cfg.lyseries)
 		lymatch = np.where(abs(lydiff)<=0.05)[0]
 		if lymatch:
-			parinfo[numpars*i+2]['limits']=[max([cfg.lowblim,bpar-10.]),min([bpar+10,cfg.upperblim_HI])]
+			parinfo[numpars*i+2]['limits']=[max([cfg.lowblim, bpar - 10.]), min([bpar + 10, cfg.upperblim_HI])]
 		else:
-			parinfo[numpars*i+2]['limits']=[max([cfg.lowblim,bpar-10.]),min([bpar+10,cfg.upperblim])]
+			parinfo[numpars*i+2]['limits']=[max([cfg.lowblim, bpar - 10.]), min([bpar + 10, cfg.upperblim])]
 		parinfo[numpars*i+2]['step']=0.5
 		parinfo[numpars*i+2]['mpside']=2
 		#parinfo[numpars*i+2]['relstep']=0.0001
@@ -138,7 +138,7 @@ def joebvpfit(wave,flux,sig,linepars,flags):
 	lam,fosc,gam=atomicdata.setatomicdata(linepars[0])
 	cfg.lams=lam ; cfg.fosc=fosc ; cfg.gam=gam
 	# Set fit regions
-	cfg.fitidx=fitpix(wave,linepars)
+	cfg.fitidx=fitpix(wave, linepars)
 	# Prep parameters for fitter
 	partofit=unfoldpars(partofit)
 	modelvars={'x':wave,'y':flux,'err':sig}
@@ -227,8 +227,8 @@ def initlinepars(zs,restwaves,initvals=[],initinfo=[]):
 	maxb=np.max(initpars[2][:])
 	minb=np.min(initpars[2][:])
 	if maxb>cfg.upperblim:
-		cfg.upperblim=maxb + 10.
-	if minb<cfg.lowblim: cfg.lowblim=minb - 2.
+		cfg.upperblim= maxb + 10.
+	if minb<cfg.lowblim: cfg.lowblim= minb - 2.
 
 	parinfo=np.zeros([5,len(restwaves)],dtype=int)
 	parinfo[0]=parinfo[0]+1
@@ -388,7 +388,7 @@ def errors_mc(fitpars,fiterrors,parinfo,wave,flux,err,sig=6,numiter=2000):
 	chisq=np.zeros(numiter)
 	for i in range(numiter):
 		mcpars=[fitpars[0],mcpararr[i,:,0],mcpararr[i,:,1],fitpars[3],mcpararr[i,:,2],fitpars[5],fitpars[6]]
-		cfg.fitidx=fitpix(wave,mcpars)
+		cfg.fitidx=fitpix(wave, mcpars)
 		vef= voigterrfunc(unfoldpars(mcpars),wave,flux,err,fjac=None)
 		chisq[i]=np.sum(vef[1]**2)
 	return mcpararr,chisq
@@ -561,7 +561,7 @@ def writeVPmodelByComp(outdir, spectrum, fitpars):
 
 	for comp in complist:
 		print '\n',comp.name
-		wave,model = modelFromAbsComp(cfg.spectrum,comp)
+		wave,model = modelFromAbsComp(cfg.spectrum, comp)
 		spec = copy.deepcopy(cfg.spectrum)
 		spec.flux = model
 		flist = glob.glob(outdir+'/'+comp.name+'*')

--- a/joebvp/makevoigt.py
+++ b/joebvp/makevoigt.py
@@ -91,12 +91,29 @@ def get_lsfs():
 			cfg.lsfs.append(lsf['kernel'])
 			break
 		else:
-			# QtCore.pyqtRemoveInputHook()
-			# import pdb; pdb.set_trace()
-			# QtCore.pyqtRestoreInputHook()
+
 			lamobs=np.median(cfg.wave[fg])
 			lsfmatch = jbg.wherebetween(lamobs, cfg.lsfranges[:, 0], cfg.lsfranges[:, 1])
+			if len(fg) < 10:
+				print("Line at {:.2f} AA is undersampling the LSF. Will increase number of pixels at either side to"
+					"include at least 10.".format(lamobs))
+				n_more_side = (10 - len(fg))/2 + 1
+				inds_right = [np.max(fg) + ii + 1 for ii in range(n_more_side)]
+				inds_left = [np.min(fg) - ii - 1 for ii in range(n_more_side)]
+				inds_left.sort()
+				# QtCore.pyqtRemoveInputHook()
+				# import pdb; pdb.set_trace()
+				# QtCore.pyqtRestoreInputHook()
+				fg = inds_left + fg.tolist() + inds_right
+				fg = np.array(fg)
+				print("New fg is: {}".format(fg))
+
 			lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[fg] * u.AA, kind='cubic')
+			# except:
+			# 	QtCore.pyqtRemoveInputHook()
+			# 	import pdb; pdb.set_trace()
+			# 	QtCore.pyqtRestoreInputHook()
+
 			cfg.lsfs.append(lsf['kernel'])
 
 def convolvecos(wave,profile,lines,zs):

--- a/joebvp/makevoigt.py
+++ b/joebvp/makevoigt.py
@@ -36,7 +36,7 @@ def Hfunc(x,a):
 
 def cosvoigt(vwave,vpars):
 	pars,info=joebvpfit.initlinepars(vpars[3],vpars[0],vpars,initinfo=[0,0,0])
-	cfg.fitidx=joebvpfit.fitpix(vwave,pars)
+	cfg.fitidx=joebvpfit.fitpix(vwave, pars)
 	cfg.wave=vwave
 	vflux=np.zeros(len(vwave))+1.
 	factor=voigt(vwave,vpars[0],vpars[1],vpars[2],vpars[3],vpars[4])
@@ -46,7 +46,7 @@ def cosvoigt(vwave,vpars):
 
 def cosvoigt_cont(vwave,cont,vpars):
 	pars,info=joebvpfit.initlinepars(vpars[3],vpars[0],vpars,initinfo=[0,0,0])
-	cfg.fitidx=joebvpfit.fitpix(vwave,pars)
+	cfg.fitidx=joebvpfit.fitpix(vwave, pars)
 	cfg.wave=vwave
 	vflux=np.zeros(len(vwave))+1.
 	factor=voigt(vwave,vpars[0],vpars[1],vpars[2],vpars[3],vpars[4])
@@ -71,7 +71,7 @@ def voigt(waves,line,coldens,bval,z,vels):
 		x=(lam-lam0-lam0*vels[i]/c)/dlam
 		a=gam/(4.*np.pi*(c*1e13/lam0**2*dlam))
 		vp=Hfunc(x,a)
-		tauval=np.sqrt(np.pi)*cfg.echarge**2/cfg.m_e/cfg.c**2*(lam0*1e-8)**2/dlam*1e8*(10**coldens[i])*fosc*vp
+		tauval= np.sqrt(np.pi) * cfg.echarge ** 2 / cfg.m_e / cfg.c ** 2 * (lam0 * 1e-8) ** 2 / dlam * 1e8 * (10 ** coldens[i]) * fosc * vp
 		tautot+=tauval
 	return np.exp(-tautot)
 
@@ -79,15 +79,15 @@ def get_lsfs():
 
 	lsfobjs=[]
 	for i,inst in enumerate(cfg.instr):
-		lsfobjs.append(LSF(dict(name=inst,grating=cfg.gratings[i],
+		lsfobjs.append(LSF(dict(name=inst, grating=cfg.gratings[i],
 								life_position=cfg.lps[i], cen_wave=cfg.cen_wave[i],
-						   		slit=cfg.slits[i])))
+								slit=cfg.slits[i])))
 	cfg.lsfs=[]
 	for fg in cfg.fgs:
 		if isinstance(fg,int):
 			lamobs=cfg.wave[fg]
 			lsfmatch = jbg.wherebetween(lamobs, cfg.lsfranges[:, 0], cfg.lsfranges[:, 1])
-			lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[cfg.fgs] * u.AA,kind='cubic')
+			lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[cfg.fgs] * u.AA, kind='cubic')
 			cfg.lsfs.append(lsf['kernel'])
 			break
 		else:
@@ -96,7 +96,7 @@ def get_lsfs():
 			# QtCore.pyqtRestoreInputHook()
 			lamobs=np.median(cfg.wave[fg])
 			lsfmatch = jbg.wherebetween(lamobs, cfg.lsfranges[:, 0], cfg.lsfranges[:, 1])
-			lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[fg] * u.AA,kind='cubic')
+			lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[fg] * u.AA, kind='cubic')
 			cfg.lsfs.append(lsf['kernel'])
 
 def convolvecos(wave,profile,lines,zs):
@@ -113,31 +113,31 @@ def convolvecos(wave,profile,lines,zs):
 		cfg.uqwgidxs=np.unique(cfg.wgidxs)
 		# Identify groups of fitidxs
 		buf=4
-		df=cfg.fitidx[1:]-cfg.fitidx[:-1]
+		df= cfg.fitidx[1:] - cfg.fitidx[:-1]
 		dividers = np.where(df > buf)[0] #These are the last indices of each group
 		if len(dividers)==0:
 			cfg.fgs=cfg.fitidx
 		else:
-			cfg.fgs=[np.arange(cfg.fitidx[0],cfg.fitidx[dividers[0]])] #1st group
+			cfg.fgs=[np.arange(cfg.fitidx[0], cfg.fitidx[dividers[0]])] #1st group
 			for i, idx in enumerate(dividers[:-1]):
-				cfg.fgs.append(np.arange(cfg.fitidx[idx+1],cfg.fitidx[dividers[i+1]])) # 'i+1' b/c 1st group handled separately
-			cfg.fgs.append(np.arange(cfg.fitidx[dividers[-1]+1],cfg.fitidx[-1]+1))  #last group
+				cfg.fgs.append(np.arange(cfg.fitidx[idx + 1], cfg.fitidx[dividers[i + 1]])) # 'i+1' b/c 1st group handled separately
+			cfg.fgs.append(np.arange(cfg.fitidx[dividers[-1] + 1], cfg.fitidx[-1] + 1))  #last group
 			newfgs=[]
 			### Deal with wavegroups that may have huge jumps in wavelength between pixels
 			for i,fg in enumerate(cfg.fgs):
 
-				diffs=cfg.wave[fg[1:]]-cfg.wave[fg[:-1]]
+				diffs= cfg.wave[fg[1:]] - cfg.wave[fg[:-1]]
 				outlier=np.where(diffs>(30.*np.median(diffs)))[0]
 
 				if len(outlier)>0:
 					if len(outlier)==1:
-						cfg.fgs[i]=np.arange(fg[0],fg[outlier+1])
+						cfg.fgs[i]=np.arange(fg[0], fg[outlier + 1])
 						newfgs.append(np.arange(fg[outlier]+1,fg[-1]))
 						if len(newfgs[-1])<15:
 							nummorepix=15-len(newfgs)
 							newfgs[-1]=np.concatenate([newfgs[-1],np.arange(fg[-1],fg[-1]+nummorepix+1)])  #add 1 to 2nd arg to make sure this val is included
 					else:
-						cfg.fgs[i]=np.arange(fg[0],fg[outlier[0]])
+						cfg.fgs[i]=np.arange(fg[0], fg[outlier[0]])
 						for j,out in enumerate(outlier):
 							if out==outlier[-1]:
 								newfgs.append(np.arange(fg[out]+1,fg[-1]+1)) #add 1 to 2nd arg to make sure this val is included
@@ -153,7 +153,7 @@ def convolvecos(wave,profile,lines,zs):
 	convprof=profile
 	for i,ll in enumerate(cfg.fgs):
 		if isinstance(ll,int):
-			lsfwidth=len(cfg.fgs)/2+1
+			lsfwidth= len(cfg.fgs) / 2 + 1
 			paddedprof = np.insert(profile[cfg.fgs], 0, [1.] * lsfwidth)
 			paddedprof = np.append(paddedprof, [1.] * lsfwidth)
 			convprof[cfg.fgs] = convolve(paddedprof, cfg.lsfs[i], mode='same')[lsfwidth:-lsfwidth]

--- a/joebvp/makevoigt.py
+++ b/joebvp/makevoigt.py
@@ -30,157 +30,162 @@ c=const.c.value/1e3
 modpath=os.path.dirname(__file__)
 
 def Hfunc(x,a):
-	z=x+1j*a
-	I=wofz(z).real
-	return I
+    z=x+1j*a
+    I=wofz(z).real
+    return I
 
 def cosvoigt(vwave,vpars):
-	pars,info=joebvpfit.initlinepars(vpars[3],vpars[0],vpars,initinfo=[0,0,0])
-	cfg.fitidx=joebvpfit.fitpix(vwave, pars)
-	cfg.wave=vwave
-	vflux=np.zeros(len(vwave))+1.
-	factor=voigt(vwave,vpars[0],vpars[1],vpars[2],vpars[3],vpars[4])
-	convfactor=convolvecos(vwave,factor,vpars[0],vpars[3])
-	vflux*=convfactor
-	return vflux
+    pars,info=joebvpfit.initlinepars(vpars[3],vpars[0],vpars,initinfo=[0,0,0])
+    cfg.fitidx=joebvpfit.fitpix(vwave, pars)
+    cfg.wave=vwave
+    vflux=np.zeros(len(vwave))+1.
+    factor=voigt(vwave,vpars[0],vpars[1],vpars[2],vpars[3],vpars[4])
+    convfactor=convolvecos(vwave,factor,vpars[0],vpars[3])
+    vflux*=convfactor
+    return vflux
 
 def cosvoigt_cont(vwave,cont,vpars):
-	pars,info=joebvpfit.initlinepars(vpars[3],vpars[0],vpars,initinfo=[0,0,0])
-	cfg.fitidx=joebvpfit.fitpix(vwave, pars)
-	cfg.wave=vwave
-	vflux=np.zeros(len(vwave))+1.
-	factor=voigt(vwave,vpars[0],vpars[1],vpars[2],vpars[3],vpars[4])
-	convfactor=convolvecos(vwave,factor*cont,vpars[0],vpars[3])
-	vflux*=convfactor
-	return vflux
+    pars,info=joebvpfit.initlinepars(vpars[3],vpars[0],vpars,initinfo=[0,0,0])
+    cfg.fitidx=joebvpfit.fitpix(vwave, pars)
+    cfg.wave=vwave
+    vflux=np.zeros(len(vwave))+1.
+    factor=voigt(vwave,vpars[0],vpars[1],vpars[2],vpars[3],vpars[4])
+    convfactor=convolvecos(vwave,factor*cont,vpars[0],vpars[3])
+    vflux*=convfactor
+    return vflux
 
 def voigt(waves,line,coldens,bval,z,vels):
-	tautot=np.zeros(len(waves))
-	if len(cfg.lams)==0:
-		lam,fosc,gam=atomicdata.setatomicdata(line)
-		cfg.lams=lam ; cfg.fosc=fosc ; cfg.gam=gam
-	for i in range(len(coldens)):
-		#thatfactor=(1.+z[i])*(1.+vels[i]/c)
-		thatfactor=(1.+z[i])
+    tautot=np.zeros(len(waves))
+    if len(cfg.lams)==0:
+        lam,fosc,gam=atomicdata.setatomicdata(line)
+        cfg.lams=lam ; cfg.fosc=fosc ; cfg.gam=gam
+    for i in range(len(coldens)):
+        #thatfactor=(1.+z[i])*(1.+vels[i]/c)
+        thatfactor=(1.+z[i])
 
-		lam0=cfg.lams[i]
-		gam=cfg.gam[i]
-		fosc=cfg.fosc[i]
-		lam = waves/thatfactor
-		dlam=bval[i]*lam0/c  #Doppler param in wavelength
-		x=(lam-lam0-lam0*vels[i]/c)/dlam
-		a=gam/(4.*np.pi*(c*1e13/lam0**2*dlam))
-		vp=Hfunc(x,a)
-		tauval= np.sqrt(np.pi) * cfg.echarge ** 2 / cfg.m_e / cfg.c ** 2 * (lam0 * 1e-8) ** 2 / dlam * 1e8 * (10 ** coldens[i]) * fosc * vp
-		tautot+=tauval
-	return np.exp(-tautot)
+        lam0=cfg.lams[i]
+        gam=cfg.gam[i]
+        fosc=cfg.fosc[i]
+        lam = waves/thatfactor
+        dlam=bval[i]*lam0/c  #Doppler param in wavelength
+        x=(lam-lam0-lam0*vels[i]/c)/dlam
+        a=gam/(4.*np.pi*(c*1e13/lam0**2*dlam))
+        vp=Hfunc(x,a)
+        tauval= np.sqrt(np.pi) * cfg.echarge ** 2 / cfg.m_e / cfg.c ** 2 * (lam0 * 1e-8) ** 2 / dlam * 1e8 * (10 ** coldens[i]) * fosc * vp
+        tautot+=tauval
+    return np.exp(-tautot)
 
 def get_lsfs():
 
-	lsfobjs=[]
-	for i,inst in enumerate(cfg.instr):
-		lsfobjs.append(LSF(dict(name=inst, grating=cfg.gratings[i],
-								life_position=cfg.lps[i], cen_wave=cfg.cen_wave[i],
-								slit=cfg.slits[i])))
-	cfg.lsfs=[]
-	for fg in cfg.fgs:
-		if isinstance(fg,int):
-			lamobs=cfg.wave[fg]
-			lsfmatch = jbg.wherebetween(lamobs, cfg.lsfranges[:, 0], cfg.lsfranges[:, 1])
-			lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[cfg.fgs] * u.AA, kind='cubic')
-			cfg.lsfs.append(lsf['kernel'])
-			break
-		else:
+    lsfobjs=[]
+    for i,inst in enumerate(cfg.instr):
+        lsfobjs.append(LSF(dict(name=inst, grating=cfg.gratings[i],
+                                life_position=cfg.lps[i], cen_wave=cfg.cen_wave[i],
+                                slit=cfg.slits[i])))
+    cfg.lsfs=[]
+    for fg in cfg.fgs:
+        if isinstance(fg,int):
+            lamobs=cfg.wave[fg]
+            lsfmatch = jbg.wherebetween(lamobs, cfg.lsfranges[:, 0], cfg.lsfranges[:, 1])
+            lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[cfg.fgs] * u.AA, kind='cubic')
+            cfg.lsfs.append(lsf['kernel'])
+            break
+        else:
 
-			lamobs=np.median(cfg.wave[fg])
-			lsfmatch = jbg.wherebetween(lamobs, cfg.lsfranges[:, 0], cfg.lsfranges[:, 1])
-			if len(fg) < 10:
-				print("Line at {:.2f} AA is undersampling the LSF. Will increase number of pixels at either side to"
-					"include at least 10.".format(lamobs))
-				n_more_side = (10 - len(fg))/2 + 1
-				inds_right = [np.max(fg) + ii + 1 for ii in range(n_more_side)]
-				inds_left = [np.min(fg) - ii - 1 for ii in range(n_more_side)]
-				inds_left.sort()
-				# QtCore.pyqtRemoveInputHook()
-				# import pdb; pdb.set_trace()
-				# QtCore.pyqtRestoreInputHook()
-				fg = inds_left + fg.tolist() + inds_right
-				fg = np.array(fg)
-				print("New fg is: {}".format(fg))
+            lamobs=np.median(cfg.wave[fg])
+            lsfmatch = jbg.wherebetween(lamobs, cfg.lsfranges[:, 0], cfg.lsfranges[:, 1])
+            if len(fg) < 10:
+                print("Line at {:.2f} AA is undersampling the LSF. Will increase number of pixels at either side to"
+                    "include at least 10.".format(lamobs))
+                n_more_side = (10 - len(fg))/2 + 1
+                inds_right = [np.max(fg) + ii + 1 for ii in range(n_more_side)]
+                inds_left = [np.min(fg) - ii - 1 for ii in range(n_more_side)]
+                inds_left.sort()
+                # QtCore.pyqtRemoveInputHook()
+                # import pdb; pdb.set_trace()
+                # QtCore.pyqtRestoreInputHook()
+                fg = inds_left + fg.tolist() + inds_right
+                fg = np.array(fg)
+                print("New fg is: {}".format(fg))
 
-			lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[fg] * u.AA, kind='cubic')
-			# except:
-			# 	QtCore.pyqtRemoveInputHook()
-			# 	import pdb; pdb.set_trace()
-			# 	QtCore.pyqtRestoreInputHook()
+            lsf = lsfobjs[lsfmatch[0]].interpolate_to_wv_array(cfg.wave[fg] * u.AA, kind='cubic')
+            # except:
+            # 	QtCore.pyqtRemoveInputHook()
+            # 	import pdb; pdb.set_trace()
+            # 	QtCore.pyqtRestoreInputHook()
 
-			cfg.lsfs.append(lsf['kernel'])
+            cfg.lsfs.append(lsf['kernel'])
 
 def convolvecos(wave,profile,lines,zs):
-	if len(wave)>len(cfg.fitidx):
-		fitwaves=wave[cfg.fitidx]
-	else:
-		fitwaves=wave
-	if cfg.wavegroups==[]:
-		X = np.array(zip(fitwaves,np.zeros(len(fitwaves))), dtype=float)
-		ms = MeanShift(bandwidth=25.)
-		ms.fit(X)
-		cfg.wgidxs = ms.labels_
-		cfg.wavegroups = ms.cluster_centers_
-		cfg.uqwgidxs=np.unique(cfg.wgidxs)
-		# Identify groups of fitidxs
-		buf=4
-		df= cfg.fitidx[1:] - cfg.fitidx[:-1]
-		dividers = np.where(df > buf)[0] #These are the last indices of each group
-		if len(dividers)==0:
-			cfg.fgs=cfg.fitidx
-		else:
-			cfg.fgs=[np.arange(cfg.fitidx[0], cfg.fitidx[dividers[0]])] #1st group
-			for i, idx in enumerate(dividers[:-1]):
-				cfg.fgs.append(np.arange(cfg.fitidx[idx + 1], cfg.fitidx[dividers[i + 1]])) # 'i+1' b/c 1st group handled separately
-			cfg.fgs.append(np.arange(cfg.fitidx[dividers[-1] + 1], cfg.fitidx[-1] + 1))  #last group
-			newfgs=[]
-			### Deal with wavegroups that may have huge jumps in wavelength between pixels
-			for i,fg in enumerate(cfg.fgs):
+    if len(wave)>len(cfg.fitidx):
+        if len(cfg.fitidx) > 0:
+            fitwaves=wave[cfg.fitidx]
+        else:
+            # todo: figure out why are there cfg.fitidx = []?
+            pass
+            # import pdb; pdb.set_trace()
+    else:
+        fitwaves=wave
+    if cfg.wavegroups==[]:
+        X = np.array(zip(fitwaves,np.zeros(len(fitwaves))), dtype=float)
+        ms = MeanShift(bandwidth=25.)
+        ms.fit(X)
+        cfg.wgidxs = ms.labels_
+        cfg.wavegroups = ms.cluster_centers_
+        cfg.uqwgidxs=np.unique(cfg.wgidxs)
+        # Identify groups of fitidxs
+        buf=4
+        df= cfg.fitidx[1:] - cfg.fitidx[:-1]
+        dividers = np.where(df > buf)[0] #These are the last indices of each group
+        if len(dividers)==0:
+            cfg.fgs=cfg.fitidx
+        else:
+            cfg.fgs=[np.arange(cfg.fitidx[0], cfg.fitidx[dividers[0]])] #1st group
+            for i, idx in enumerate(dividers[:-1]):
+                cfg.fgs.append(np.arange(cfg.fitidx[idx + 1], cfg.fitidx[dividers[i + 1]])) # 'i+1' b/c 1st group handled separately
+            cfg.fgs.append(np.arange(cfg.fitidx[dividers[-1] + 1], cfg.fitidx[-1] + 1))  #last group
+            newfgs=[]
+            ### Deal with wavegroups that may have huge jumps in wavelength between pixels
+            for i,fg in enumerate(cfg.fgs):
 
-				diffs= cfg.wave[fg[1:]] - cfg.wave[fg[:-1]]
-				outlier=np.where(diffs>(30.*np.median(diffs)))[0]
+                diffs= cfg.wave[fg[1:]] - cfg.wave[fg[:-1]]
+                outlier=np.where(diffs>(30.*np.median(diffs)))[0]
 
-				if len(outlier)>0:
-					if len(outlier)==1:
-						cfg.fgs[i]=np.arange(fg[0], fg[outlier + 1])
-						newfgs.append(np.arange(fg[outlier]+1,fg[-1]))
-						if len(newfgs[-1])<15:
-							nummorepix=15-len(newfgs)
-							newfgs[-1]=np.concatenate([newfgs[-1],np.arange(fg[-1],fg[-1]+nummorepix+1)])  #add 1 to 2nd arg to make sure this val is included
-					else:
-						cfg.fgs[i]=np.arange(fg[0], fg[outlier[0]])
-						for j,out in enumerate(outlier):
-							if out==outlier[-1]:
-								newfgs.append(np.arange(fg[out]+1,fg[-1]+1)) #add 1 to 2nd arg to make sure this val is included
-							else:
-								newfgs.append(np.arange(fg[out]+1,fg[outlier[j+1]]+1))   #add 1 to 2nd arg to make sure this val is included
-							if len(newfgs[-1])<15:
-								nummorepix=15-len(newfgs)
-								newfgs[-1]=np.concatenate([newfgs[-1],np.arange(fg[-1],fg[-1]+nummorepix+1)]) #add 1 to 2nd arg to make sure this val is included
+                if len(outlier)>0:
+                    if len(outlier)==1:
+                        cfg.fgs[i]=np.arange(fg[0], fg[outlier + 1])
+                        newfgs.append(np.arange(fg[outlier]+1,fg[-1]))
+                        if len(newfgs[-1])<15:
+                            nummorepix=15-len(newfgs)
+                            newfgs[-1]=np.concatenate([newfgs[-1],np.arange(fg[-1],fg[-1]+nummorepix+1)])  #add 1 to 2nd arg to make sure this val is included
+                    else:
+                        cfg.fgs[i]=np.arange(fg[0], fg[outlier[0]])
+                        for j,out in enumerate(outlier):
+                            if out==outlier[-1]:
+                                newfgs.append(np.arange(fg[out]+1,fg[-1]+1)) #add 1 to 2nd arg to make sure this val is included
+                            else:
+                                newfgs.append(np.arange(fg[out]+1,fg[outlier[j+1]]+1))   #add 1 to 2nd arg to make sure this val is included
+                            if len(newfgs[-1])<15:
+                                nummorepix=15-len(newfgs)
+                                newfgs[-1]=np.concatenate([newfgs[-1],np.arange(fg[-1],fg[-1]+nummorepix+1)]) #add 1 to 2nd arg to make sure this val is included
 
-			for fg in newfgs:
-				cfg.fgs.append(fg)
-		get_lsfs()
-	convprof=profile
-	for i,ll in enumerate(cfg.fgs):
-		if isinstance(ll,int):
-			lsfwidth= len(cfg.fgs) / 2 + 1
-			paddedprof = np.insert(profile[cfg.fgs], 0, [1.] * lsfwidth)
-			paddedprof = np.append(paddedprof, [1.] * lsfwidth)
-			convprof[cfg.fgs] = convolve(paddedprof, cfg.lsfs[i], mode='same')[lsfwidth:-lsfwidth]
-			break
-		else:
+            for fg in newfgs:
+                cfg.fgs.append(fg)
+        get_lsfs()
+    convprof=profile
+    for i,ll in enumerate(cfg.fgs):
+        if isinstance(ll,int):
+            lsfwidth= len(cfg.fgs) / 2 + 1
+            paddedprof = np.insert(profile[cfg.fgs], 0, [1.] * lsfwidth)
+            paddedprof = np.append(paddedprof, [1.] * lsfwidth)
+            convprof[cfg.fgs] = convolve(paddedprof, cfg.lsfs[i], mode='same')[lsfwidth:-lsfwidth]
+            break
+        else:
 
-			lsfwidth=len(ll)/2+1
-			paddedprof = np.insert(profile[ll], 0, [1.] * lsfwidth)
-			paddedprof=np.append(paddedprof,[1.]*lsfwidth)
-			convprof[ll] = convolve(paddedprof, cfg.lsfs[i], mode='same')[lsfwidth:-lsfwidth]
+            lsfwidth=len(ll)/2+1
+            paddedprof = np.insert(profile[ll], 0, [1.] * lsfwidth)
+            paddedprof=np.append(paddedprof,[1.]*lsfwidth)
+            convprof[ll] = convolve(paddedprof, cfg.lsfs[i], mode='same')[lsfwidth:-lsfwidth]
 
 
-	return convprof
+    return convprof


### PR DESCRIPTION
Some tweaks as follows:

- A new method `VPmeasure.concatenate_all()` that is a shortcut to concatenate outputs and fit inspections
- Modification to `VPmeasure.batch_fit()` so now it asks the user whether the failures fits should be done in the GUI mode after all the other are finished.
- Some cleaning in the `cfg.py` file
- Definition of bad_pixels now refactor and done as a function in joebvpfit.py module
- New global variable called `cfg.spectral_gaps` that allows the user to define bad pixels based from spectral gaps. These could be useful to mask out spectral edges, gaps, geocoronal emission lines, etc.