### PR TITLE
Changing how batch_fit handles reading single-line flist file

### DIFF
--- a/joebvp/VPmeasure.py
+++ b/joebvp/VPmeasure.py
@@ -618,8 +618,8 @@ def batch_fit(spec, filelist, outparfile='.VP', outmodelfile='_VPmodel.fits', in
     if isinstance(filelist, str):
         lstarr=np.genfromtxt(filelist,dtype=None)
         listofiles=lstarr.tolist()
-        if isinstance(listofiles,str):  # In case 'listofiles' is only 1 file
-            listofiles=[listofiles]
+        if sum(1 for line in open(filelist)) == 1:
+            listofiles = [listofiles]
     else:
         listofiles=filelist
 

--- a/joebvp/utils.py
+++ b/joebvp/utils.py
@@ -142,6 +142,8 @@ def concatenate_line_tables(filelist,outtablefile='compiledVPoutputs.dat'):
         listofiles=lstarr.tolist()
     else:
         listofiles=filelist
+    if sum(1 for line in open(filelist)) == 1:
+        listofiles = [listofiles]
     tabs = []
     for i, ff in enumerate(listofiles):
         if isinstance(ff,bytes):


### PR DESCRIPTION
I ran into an issue on my where batch_fit wouldn't run if I only had one .joebvp file. The original implementation of flagging this case wasn't working for me, so I changed the argument.  Let me know what you think / if there's a better way of doing this!